### PR TITLE
Update all Mods & Add some smaller QoL ones

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1072,8 +1072,8 @@
          "required":true
       },
       {
-         "fileID":2745846,
-         "projectID":233105,
+         "fileID":5643297,
+         "projectID":1086841,
          "required":true
       },
       {
@@ -1147,8 +1147,8 @@
          "required":true
       },
       {
-         "fileID":2861573,
-         "projectID":224641,
+         "fileID":6851134,
+         "projectID":1085014,
          "required":true
       },
       {

--- a/manifest.json
+++ b/manifest.json
@@ -277,11 +277,6 @@
          "required":true
       },
       {
-         "fileID":4674242,
-         "projectID":309756,
-         "required":true
-      },
-      {
          "fileID":4674241,
          "projectID":304346,
          "required":true

--- a/manifest.json
+++ b/manifest.json
@@ -407,8 +407,8 @@
          "required":true
       },
       {
-         "fileID":2923460,
-         "projectID":223094,
+         "fileID":7650535,
+         "projectID":632327,
          "required":true
       },
       {
@@ -1152,11 +1152,6 @@
          "required":true
       },
       {
-         "fileID":3133651,
-         "projectID":285612,
-         "required":true
-      },
-      {
          "fileID":2861573,
          "projectID":224641,
          "required":true
@@ -1275,7 +1270,17 @@
          "fileID":7455761,
          "projectID":873867,
          "required":true
-      }
+      },
+      {
+         "fileID":7929464,
+         "projectID":624243,
+         "required":true
+      },
+      {
+         "fileID":5951859,
+         "projectID":928895,
+         "required":true
+      },
    ],
    "manifestType":"minecraftModpack",
    "manifestVersion":1,

--- a/manifest.json
+++ b/manifest.json
@@ -1270,6 +1270,11 @@
          "fileID":5951859,
          "projectID":928895,
          "required":true
+      },
+      {
+         "fileID":5212709,
+         "projectID":870276,
+         "required":true
       }
    ],
    "manifestType":"minecraftModpack",

--- a/manifest.json
+++ b/manifest.json
@@ -1265,6 +1265,11 @@
          "fileID":6495943,
          "projectID":895539,
          "required":true
+      },
+      {
+         "fileID":7695929,
+         "projectID":456402,
+         "required":true
       }
    ],
    "manifestType":"minecraftModpack",

--- a/manifest.json
+++ b/manifest.json
@@ -572,18 +572,13 @@
          "required":true
       },
       {
-         "fileID":2699056,
-         "projectID":228816,
+         "fileID":7294306,
+         "projectID":1342654,
          "required":true
       },
       {
          "fileID":6608365,
          "projectID":223008,
-         "required":true
-      },
-      {
-         "fileID":2699055,
-         "projectID":228815,
          "required":true
       },
       {
@@ -1280,7 +1275,7 @@
          "fileID":5951859,
          "projectID":928895,
          "required":true
-      },
+      }
    ],
    "manifestType":"minecraftModpack",
    "manifestVersion":1,

--- a/manifest.json
+++ b/manifest.json
@@ -267,13 +267,13 @@
          "required":true
       },
       {
-         "fileID":4671384,
-         "projectID":231868,
+         "fileID":8025612,
+         "projectID":1530852,
          "required":true
       },
       {
-         "fileID":4674244,
-         "projectID":64578,
+         "fileID":8025615,
+         "projectID":1530854,
          "required":true
       },
       {

--- a/manifest.json
+++ b/manifest.json
@@ -1255,6 +1255,11 @@
          "fileID":5814089,
          "projectID":1121489,
          "required":true
+      },
+      {
+         "fileID":8015917,
+         "projectID":1052470,
+         "required":true
       }
    ],
    "manifestType":"minecraftModpack",

--- a/manifest.json
+++ b/manifest.json
@@ -1137,8 +1137,8 @@
          "required":true
       },
       {
-         "fileID":4724647,
-         "projectID":620262,
+         "fileID":6687458,
+         "projectID":910715,
          "required":true
       },
       {
@@ -1269,6 +1269,11 @@
       {
          "fileID":7695929,
          "projectID":456402,
+         "required":true
+      },
+      {
+         "fileID":7455761,
+         "projectID":873867,
          "required":true
       }
    ],

--- a/manifest.json
+++ b/manifest.json
@@ -1260,6 +1260,11 @@
          "fileID":8015917,
          "projectID":1052470,
          "required":true
+      },
+      {
+         "fileID":6495943,
+         "projectID":895539,
+         "required":true
       }
    ],
    "manifestType":"minecraftModpack",

--- a/manifest.json
+++ b/manifest.json
@@ -702,8 +702,8 @@
          "required":true
       },
       {
-         "fileID":2902483,
-         "projectID":74072,
+         "fileID":7999105,
+         "projectID":1242239,
          "required":true
       },
       {

--- a/manifest.json
+++ b/manifest.json
@@ -1250,6 +1250,11 @@
          "fileID":2745852,
          "projectID":260912,
          "required":true
+      },
+      {
+         "fileID":5814089,
+         "projectID":1121489,
+         "required":true
       }
    ],
    "manifestType":"minecraftModpack",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
    "author":"",
    "files":[
       {
-         "fileID":5079135,
+         "fileID":7049694,
          "projectID":419286,
          "required":true
       },
@@ -22,7 +22,7 @@
          "required":true
       },
       {
-         "fileID":3801020,
+         "fileID":4671856,
          "projectID":236542,
          "required":true
       },
@@ -47,7 +47,7 @@
          "required":true
       },
       {
-         "fileID":4391401,
+         "fileID":5225456,
          "projectID":321792,
          "required":true
       },
@@ -82,7 +82,7 @@
          "required":true
       },
       {
-         "fileID":4010084,
+         "fileID":7859791,
          "projectID":629629,
          "required":true
       },
@@ -172,7 +172,7 @@
          "required":true
       },
       {
-         "fileID":3025548,
+         "fileID":5408385,
          "projectID":250398,
          "required":true
       },
@@ -192,7 +192,7 @@
          "required":true
       },
       {
-         "fileID":4036242,
+         "fileID":8043693,
          "projectID":239197,
          "required":true
       },
@@ -217,7 +217,7 @@
          "required":true
       },
       {
-         "fileID":3722420,
+         "fileID":4075832,
          "projectID":239286,
          "required":true
       },
@@ -267,22 +267,22 @@
          "required":true
       },
       {
-         "fileID":2972849,
+         "fileID":4671384,
          "projectID":231868,
          "required":true
       },
       {
-         "fileID":3328811,
+         "fileID":4674244,
          "projectID":64578,
          "required":true
       },
       {
-         "fileID":3328809,
+         "fileID":4674242,
          "projectID":309756,
          "required":true
       },
       {
-         "fileID":3328808,
+         "fileID":4674241,
          "projectID":304346,
          "required":true
       },
@@ -299,11 +299,6 @@
       {
          "fileID":2966941,
          "projectID":241967,
-         "required":true
-      },
-      {
-         "fileID":3613140,
-         "projectID":398267,
          "required":true
       },
       {
@@ -332,12 +327,12 @@
          "required":true
       },
       {
-         "fileID":4417951,
+         "fileID":5751930,
          "projectID":623955,
          "required":true
       },
       {
-         "fileID":4430381,
+         "fileID":7581579,
          "projectID":485654,
          "required":true
       },
@@ -362,7 +357,7 @@
          "required":true
       },
       {
-         "fileID":4476120,
+         "fileID":7316351,
          "projectID":715086,
          "required":true
       },
@@ -377,7 +372,7 @@
          "required":true
       },
       {
-         "fileID":4109510,
+         "fileID":8003309,
          "projectID":557549,
          "required":true
       },
@@ -432,7 +427,7 @@
          "required":true
       },
       {
-         "fileID":4318448,
+         "fileID":6937116,
          "projectID":616190,
          "required":true
       },
@@ -447,7 +442,7 @@
          "required":true
       },
       {
-         "fileID":2728585,
+         "fileID":4440935,
          "projectID":240630,
          "required":true
       },
@@ -462,7 +457,7 @@
          "required":true
       },
       {
-         "fileID":4499615,
+         "fileID":5734973,
          "projectID":532127,
          "required":true
       },
@@ -477,7 +472,7 @@
          "required":true
       },
       {
-         "fileID":3507866,
+         "fileID":7684381,
          "projectID":255257,
          "required":true
       },
@@ -492,7 +487,7 @@
          "required":true
       },
       {
-         "fileID":3658279,
+         "fileID":7911482,
          "projectID":359407,
          "required":true
       },
@@ -507,12 +502,12 @@
          "required":true
       },
       {
-         "fileID":4557906,
+         "fileID":7780583,
          "projectID":399904,
          "required":true
       },
       {
-         "fileID":4557905,
+         "fileID":7780588,
          "projectID":813408,
          "required":true
       },
@@ -527,12 +522,7 @@
          "required":true
       },
       {
-         "fileID":3962479,
-         "projectID":461660,
-         "required":true
-      },
-      {
-         "fileID":4397880,
+         "fileID":6926531,
          "projectID":827020,
          "required":true
       },
@@ -567,18 +557,13 @@
          "required":true
       },
       {
-         "fileID":4382001,
+         "fileID":6325382,
          "projectID":515565,
          "required":true
       },
       {
          "fileID":2695044,
          "projectID":235107,
-         "required":true
-      },
-      {
-         "fileID":3784145,
-         "projectID":226254,
          "required":true
       },
       {
@@ -592,7 +577,7 @@
          "required":true
       },
       {
-         "fileID":3966135,
+         "fileID":6608365,
          "projectID":223008,
          "required":true
       },
@@ -607,17 +592,17 @@
          "required":true
       },
       {
-         "fileID":4421216,
+         "fileID":7762599,
          "projectID":811828,
          "required":true
       },
       {
-         "fileID":4420185,
+         "fileID":7329681,
          "projectID":308380,
          "required":true
       },
       {
-         "fileID":4415275,
+         "fileID":6928168,
          "projectID":322861,
          "required":true
       },
@@ -632,7 +617,7 @@
          "required":true
       },
       {
-         "fileID":2694382,
+         "fileID":4629597,
          "projectID":283644,
          "required":true
       },
@@ -657,7 +642,7 @@
          "required":true
       },
       {
-         "fileID":3895715,
+         "fileID":7215216,
          "projectID":417392,
          "required":true
       },
@@ -667,7 +652,7 @@
          "required":true
       },
       {
-         "fileID":3826315,
+         "fileID":4408001,
          "projectID":237701,
          "required":true
       },
@@ -717,7 +702,7 @@
          "required":true
       },
       {
-         "fileID":2952606,
+         "fileID":5981297,
          "projectID":223852,
          "required":true
       },
@@ -742,7 +727,7 @@
          "required":true
       },
       {
-         "fileID":4486505,
+         "fileID":6047659,
          "projectID":319441,
          "required":true
       },
@@ -757,7 +742,7 @@
          "required":true
       },
       {
-         "fileID":2705304,
+         "fileID":5646810,
          "projectID":285492,
          "required":true
       },
@@ -807,7 +792,7 @@
          "required":true
       },
       {
-         "fileID":4473327,
+         "fileID":7849634,
          "projectID":705000,
          "required":true
       },
@@ -822,7 +807,7 @@
          "required":true
       },
       {
-         "fileID":3064112,
+         "fileID":4623135,
          "projectID":253043,
          "required":true
       },
@@ -842,7 +827,7 @@
          "required":true
       },
       {
-         "fileID":5088803,
+         "fileID":6302098,
          "projectID":570458,
          "required":true
       },
@@ -857,7 +842,7 @@
          "required":true
       },
       {
-         "fileID":2750633,
+         "fileID":4344128,
          "projectID":277631,
          "required":true
       },
@@ -907,18 +892,13 @@
          "required":true
       },
       {
-         "fileID":3498879,
+         "fileID":4507139,
          "projectID":274259,
          "required":true
       },
       {
          "fileID":2992872,
          "projectID":282001,
-         "required":true
-      },
-      {
-         "fileID":4800875,
-         "projectID":460609,
          "required":true
       },
       {
@@ -972,6 +952,11 @@
          "required":true
       },
       {
+         "fileID":5778512,
+         "projectID":398267,
+         "required":true
+      },
+      {
          "fileID":2678374,
          "projectID":225561,
          "required":true
@@ -982,7 +967,7 @@
          "required":true
       },
       {
-         "fileID":2918418,
+         "fileID":7398359,
          "projectID":59751,
          "required":true
       },
@@ -1007,7 +992,7 @@
          "required":true
       },
       {
-         "fileID":2666979,
+         "fileID":4136686,
          "projectID":311846,
          "required":true
       },
@@ -1022,7 +1007,7 @@
          "required":true
       },
       {
-         "fileID":2728635,
+         "fileID":3838713,
          "projectID":242638,
          "required":true
       },
@@ -1062,7 +1047,7 @@
          "required":true
       },
       {
-         "fileID":2916002,
+         "fileID":5172461,
          "projectID":32274,
          "required":true
       },
@@ -1079,6 +1064,11 @@
       {
          "fileID":3116493,
          "projectID":243298,
+         "required":true
+      },
+      {
+         "fileID":8043208,
+         "projectID":460609,
          "required":true
       },
       {
@@ -1102,7 +1092,12 @@
          "required":true
       },
       {
-         "fileID":4124891,
+         "fileID":5876158,
+         "projectID":461660,
+         "required":true
+      },
+      {
+         "fileID":6786327,
          "projectID":604054,
          "required":true
       },
@@ -1117,7 +1112,12 @@
          "required":true
       },
       {
-         "fileID":4805869,
+         "fileID":6151363,
+         "projectID":226254,
+         "required":true
+      },
+      {
+         "fileID":7476868,
          "projectID":923677,
          "required":true
       },
@@ -1137,7 +1137,7 @@
          "required":true
       },
       {
-         "fileID":3909215,
+         "fileID":4724647,
          "projectID":620262,
          "required":true
       },
@@ -1147,7 +1147,7 @@
          "required":true
       },
       {
-         "fileID":3648592,
+         "fileID":4703532,
          "projectID":376903,
          "required":true
       },
@@ -1172,7 +1172,7 @@
          "required":true
       },
       {
-         "fileID":3107974,
+         "fileID":6031613,
          "projectID":256141,
          "required":true
       },
@@ -1202,7 +1202,7 @@
          "required":true
       },
       {
-         "fileID":4485344,
+         "fileID":6321322,
          "projectID":849094,
          "required":true
       },
@@ -1237,7 +1237,7 @@
          "required":true
       },
       {
-         "fileID":5010926,
+         "fileID":7958801,
          "projectID":871198,
          "required":true
       },


### PR DESCRIPTION
Updates:
- Update all Mods to their latest versions except for JAOPCA, 2.3.x yeeted SR2 and Ex Nihilo compat so it's only updated to the latest 2.2.x version

Replacements:
- Replace Tinkers Construct -> Tinkers Antique
- Replace Openblocks & OpenModsLib -> Openblocks Reopened
- Replace RFTools -> RefinedTools
- Replace McJtyLib -> McJtyLib Refilmed
- Replace Inventory Tweaks -> Inventory Bogo Sorter
- Replace Hesperus -> Alfheim
- Replace EnderIO -> EnderIO CEu
- Replace EnderCore -> EnderCore CEu

Additions:
- Add Extreme Sound Muffler
- Add IC2 Patcher
- Add VisualOres
- Add AE2 Crafting Tree - Legacy
- Add ConfigAnytime (Dependency for updated Universal Tweaks)
- Add Key Binding Patch (Dependency of Inventory Bogo Sorter)
- Add ModularUI (Dependency of Inventory Bogo Sorter)
- Add Red Core (Dependency of Alfheim & McJtyLib Refilmed)

Removals:
- Remove RandomPatches (Incompatible with ModularUI)